### PR TITLE
화면 종류에 따른 스타일링 방식 모듈화

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -11,7 +11,9 @@ import Debug from './components/Debug';
 import ScreenHeightMeasure from './components/ScreenHeightMeasure';
 import YTPlayer from './components/YTPlayer';
 import YTWrapper from './components/YTWrapper';
-import useScreenType, { ScreenType } from './hooks/useScreenType';
+import useScreenType from './hooks/useScreenType';
+import ScreenType from './types/screen';
+import { conditionalClassName } from './utils/style';
 
 function App() {
   const screenType = useScreenType();
@@ -44,11 +46,11 @@ function App() {
         <br />
         {/* Tailwind screen prefix에 대한 workaround (이슈 #49 참조) */}
         <span
-          className={{
-            [ScreenType.MobilePortait]: 'text-red-500',
-            [ScreenType.MobileLandscape]: 'text-green-500',
-            [ScreenType.Desktop]: 'text-blue-500',
-          }[screenType]}
+          className={conditionalClassName({
+            desktop: 'text-blue-500',
+            mobileLandscape: 'text-green-500',
+            mobilePortrait: 'text-red-500',
+          })(screenType)}
         >
           Screen type:
           {' '}

--- a/packages/frontend/src/components/YTWrapper.module.css
+++ b/packages/frontend/src/components/YTWrapper.module.css
@@ -12,7 +12,7 @@
 
 /* Mobile Portrait */
 
-.minMobilePortait {
+.minMobilePortrait {
   transition: opacity 400ms cubic-bezier(0.4, 0, 0.2, 1);
   width: var(--pip-width--mobile);
   height: var(--pip-height--mobile);
@@ -23,7 +23,7 @@
   border-radius: 0.5rem;
 }
 
-.maxMobilePortait {
+.maxMobilePortrait {
   transition: opacity 400ms cubic-bezier(0.4, 0, 0.2, 1);
   width: 100vw;
   height: 56.25vw;
@@ -31,7 +31,7 @@
   border-radius: 0rem;
 }
 
-.beingMinMobilePortait {
+.beingMinMobilePortrait {
   transition: all 400ms cubic-bezier(0.4, 0, 0.2, 1);
   width: var(--pip-width--mobile);
   height: var(--pip-height--mobile);
@@ -42,7 +42,7 @@
   border-radius: 0.5rem;
 }
 
-.beingMaxMobilePortait {
+.beingMaxMobilePortrait {
   transition: all 400ms cubic-bezier(0.4, 0, 0.2, 1);
   width: 100vw;
   height: 56.25vw;

--- a/packages/frontend/src/components/YTWrapper.tsx
+++ b/packages/frontend/src/components/YTWrapper.tsx
@@ -2,7 +2,8 @@ import { FullScreenMaximize24Filled } from '@fluentui/react-icons';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 
-import useScreenType, { ScreenType } from '../hooks/useScreenType';
+import useScreenType from '../hooks/useScreenType';
+import ScreenType from '../types/screen';
 import { mergeClassNames, Styled } from '../utils/style';
 
 import styles from './YTWrapper.module.css';

--- a/packages/frontend/src/hooks/useScreenType.ts
+++ b/packages/frontend/src/hooks/useScreenType.ts
@@ -19,7 +19,7 @@ const useScreenType: () => ScreenType = () => {
   if (isDesktop) {
     return ScreenType.Desktop;
   }
-  return isPortrait ? ScreenType.MobilePortait : ScreenType.MobileLandscape;
+  return isPortrait ? ScreenType.MobilePortrait : ScreenType.MobileLandscape;
 };
 
 export default useScreenType;

--- a/packages/frontend/src/hooks/useScreenType.ts
+++ b/packages/frontend/src/hooks/useScreenType.ts
@@ -1,12 +1,7 @@
 import { useRecoilValue } from 'recoil';
 
 import screenSizeState from '../recoil/screenSize';
-
-export enum ScreenType {
-  MobilePortait = 0,
-  MobileLandscape = 1,
-  Desktop = 2,
-}
+import ScreenType from '../types/screen';
 
 const CHAT_SECTION_HEIGHT_THRESHOLD = 80;
 

--- a/packages/frontend/src/types/screen.ts
+++ b/packages/frontend/src/types/screen.ts
@@ -1,0 +1,7 @@
+enum ScreenType {
+  MobilePortait = 0,
+  MobileLandscape = 1,
+  Desktop = 2,
+}
+
+export default ScreenType;

--- a/packages/frontend/src/types/screen.ts
+++ b/packages/frontend/src/types/screen.ts
@@ -1,5 +1,5 @@
 enum ScreenType {
-  MobilePortait = 0,
+  MobilePortrait = 0,
   MobileLandscape = 1,
   Desktop = 2,
 }

--- a/packages/frontend/src/utils/style.test.ts
+++ b/packages/frontend/src/utils/style.test.ts
@@ -1,0 +1,91 @@
+import ScreenType from '../types/screen';
+
+import {
+  mergeClassNames, mergeStyles, conditionalClassName, conditionalStyle,
+} from './style';
+
+describe('mergeClassNames', () => {
+  test('Should concatenate all classNames', () => {
+    expect(mergeClassNames()).toBe('');
+    expect(mergeClassNames('a', 'b', 'c')).toBe('a b c');
+    expect(mergeClassNames('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j')).toBe('a b c d e f g h i j');
+  });
+
+  test('Should remove nulls and undefineds', () => {
+    expect(mergeClassNames('a', null, 'b', undefined, 'c', null, 'd')).toBe('a b c d');
+  });
+});
+
+describe('mergeStyles', () => {
+  test('Should concatenate all styles', () => {
+    expect(mergeStyles(
+      { height: '100%', width: '100%' },
+      { backgroundColor: 'red', boxShadow: 'none' },
+    )).toStrictEqual({
+      backgroundColor: 'red', boxShadow: 'none', height: '100%', width: '100%',
+    });
+  });
+
+  test('Should remove nulls and undefineds', () => {
+    expect(mergeStyles(
+      { height: '100%', width: '100%' },
+      null,
+      { backgroundColor: 'red', boxShadow: 'none' },
+      null,
+      undefined,
+    )).toStrictEqual({
+      backgroundColor: 'red', boxShadow: 'none', height: '100%', width: '100%',
+    });
+  });
+
+  test('Later styles should override the former ones', () => {
+    expect(mergeStyles(
+      { height: '100%', width: '100%' },
+      { boxShadow: 'none', height: '100%' },
+    )).toStrictEqual({
+      boxShadow: 'none', height: '100%', width: '100%',
+    });
+  });
+});
+
+describe('conditionalClassName', () => {
+  test('Should work well', () => {
+    const classNameFunction = conditionalClassName({
+      desktop: 'desktop',
+      mobile: 'mobile',
+      mobileLandscape: 'mobileLandscape',
+      mobilePortrait: 'mobilePortrait',
+      portrait: 'portrait',
+    });
+    expect(classNameFunction(ScreenType.MobilePortrait).split(' ').sort())
+      .toStrictEqual(['mobile', 'mobilePortrait', 'portrait'].sort());
+    expect(classNameFunction(ScreenType.MobileLandscape).split(' ').sort())
+      .toStrictEqual(['mobile', 'mobileLandscape'].sort());
+    expect(classNameFunction(ScreenType.Desktop).split(' ').sort())
+      .toStrictEqual(['desktop', 'portrait'].sort());
+  });
+});
+
+describe('conditionalStyle', () => {
+  test('Should work well', () => {
+    const styleFunction = conditionalStyle({
+      desktop: { width: '1px' },
+      mobile: { height: '2px' },
+      mobileLandscape: { margin: '3px' },
+      mobilePortrait: { padding: '4px' },
+      portrait: { fontSize: '5px' },
+    });
+    expect(styleFunction(ScreenType.MobilePortrait))
+      .toStrictEqual({
+        fontSize: '5px', height: '2px', padding: '4px',
+      });
+    expect(styleFunction(ScreenType.MobileLandscape))
+      .toStrictEqual({
+        height: '2px', margin: '3px',
+      });
+    expect(styleFunction(ScreenType.Desktop))
+      .toStrictEqual({
+        fontSize: '5px', width: '1px',
+      });
+  });
+});

--- a/packages/frontend/src/utils/style.ts
+++ b/packages/frontend/src/utils/style.ts
@@ -24,14 +24,14 @@ type ScreenTypeKeys =
   | 'mobilePortrait'
   | 'mobileLandscape'
   | 'desktop'
-  | 'portrait'; // MobilePortait + Desktop
+  | 'portrait'; // MobilePortrait + Desktop
 
 type ClassNames = {
   [keys in ScreenTypeKeys]: string | null;
 };
 export function conditionalClassName(classNames: Partial<ClassNames>) {
   return (screenType: ScreenType) => mergeClassNames(
-    screenType === ScreenType.MobilePortait ? classNames.mobilePortrait : null,
+    screenType === ScreenType.MobilePortrait ? classNames.mobilePortrait : null,
     screenType === ScreenType.MobileLandscape ? classNames.mobileLandscape : null,
     screenType === ScreenType.Desktop ? classNames.desktop : null,
     screenType !== ScreenType.Desktop ? classNames.mobile : null,
@@ -44,7 +44,7 @@ type Styles = {
 };
 export function conditionalStyle(styles: Partial<Styles>) {
   return (screenType: ScreenType) => mergeStyles(
-    screenType === ScreenType.MobilePortait ? styles.mobilePortrait : null,
+    screenType === ScreenType.MobilePortrait ? styles.mobilePortrait : null,
     screenType === ScreenType.MobileLandscape ? styles.mobileLandscape : null,
     screenType === ScreenType.Desktop ? styles.desktop : null,
     screenType !== ScreenType.Desktop ? styles.mobile : null,

--- a/packages/frontend/src/utils/style.ts
+++ b/packages/frontend/src/utils/style.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import ScreenType from '../types/screen';
+
 export function mergeClassNames(...classNames: (string | null | undefined)[]): string {
   return classNames.filter((c) => !!c).join(' ');
 }
@@ -16,3 +18,36 @@ export type Styled<T> = T & {
   style?: React.CSSProperties;
   className?: string;
 };
+
+type ScreenTypeKeys =
+  | 'mobile'
+  | 'mobilePortrait'
+  | 'mobileLandscape'
+  | 'desktop'
+  | 'portrait'; // MobilePortait + Desktop
+
+type ClassNames = {
+  [keys in ScreenTypeKeys]: string | null;
+};
+export function conditionalClassName(classNames: Partial<ClassNames>) {
+  return (screenType: ScreenType) => mergeClassNames(
+    screenType === ScreenType.MobilePortait ? classNames.mobilePortrait : null,
+    screenType === ScreenType.MobileLandscape ? classNames.mobileLandscape : null,
+    screenType === ScreenType.Desktop ? classNames.desktop : null,
+    screenType !== ScreenType.Desktop ? classNames.mobile : null,
+    screenType !== ScreenType.MobileLandscape ? classNames.portrait : null,
+  );
+}
+
+type Styles = {
+  [keys in ScreenTypeKeys]: React.CSSProperties;
+};
+export function conditionalStyle(styles: Partial<Styles>) {
+  return (screenType: ScreenType) => mergeStyles(
+    screenType === ScreenType.MobilePortait ? styles.mobilePortrait : null,
+    screenType === ScreenType.MobileLandscape ? styles.mobileLandscape : null,
+    screenType === ScreenType.Desktop ? styles.desktop : null,
+    screenType !== ScreenType.Desktop ? styles.mobile : null,
+    screenType !== ScreenType.MobileLandscape ? styles.portrait : null,
+  );
+}


### PR DESCRIPTION
## 개요

이전의 스타일링 방식
```tsx
<Element
  className={{
    [ScreenType.MobilePortrait]: 'text-red-500',
    [ScreenType.MobileLandscape]: 'text-green-500',
    [ScreenType.Desktop]: 'text-blue-500',
  }[screenType]}
/>
```
또는
```tsx
<Element 
  className={screenType === ScreenType.MobilePortrait ? 'text-red-500' : screenType === ScreenType.MobileLandscape ? 'text-green-500' : 'text-blue-500'}
/>
```
을 모듈화하여
```tsx
<Element 
  className={conditionalClassName({
    mobilePortrait: 'text-red-500',
    mobileLandscape: 'text-green-500',
    desktop: 'text-blue-500',
  })(screenType)}
/>
```
로 쓰면 됩니다.

## 장점
* `ScreenType`을 불러오지 않아도 됩니다.
* `MobilePortrait`와 `MobileLandscape`를 합쳐 `mobile:`로, `MobilePortrait`와 `Desktop`를 합쳐 `portrait:`로 쓸 수 있어 공통된 클래스/스타일이 있을 때 더 간편하고 짧아집니다.
```tsx
<Element
  className={{
    [ScreenType.MobilePortrait]: 'bg-gray-200',
    [ScreenType.MobileLandscape]: 'bg-gray-900 bg-opacity-50',
    [ScreenType.Desktop]: 'bg-gray-200',
  }[screenType]}
/>
```
대신
```tsx
<Element
  className={conditionalClassName({
    portrait: 'bg-gray-200',
    mobileLandscape: 'bg-gray-900 bg-opacity-50',
  })}
/>
```
로 쓸 수 있습니다.