### PR TITLE
fix(lib): fix module resolution problem

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -94,5 +94,10 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "postcss": "^7",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@2.2.17"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "@team-10/lib(.*)$": "<rootDir>/../lib/src/$1"
+    }
   }
 }


### PR DESCRIPTION
## 개요
https://github.com/2021-fall-cs492c-team-10/monorepo/pull/77 의 module resolution 문제를 해결했습니다. 테스트가 failing하는 이유가 `@team-10/lib`을 `jest-resolve`가 적절하게 resolve하지 못해서인데 `package.json`의 `jest` property에 module resolution 관련 설정을 추가했습니다.

## 상세 사항
https://github.com/2021-fall-cs492c-team-10/monorepo/pull/78 에서 커밋을 정리한 브랜치입니다.