### PR TITLE
feat(frontend/input): implement input

### DIFF
--- a/packages/frontend/public/index.html
+++ b/packages/frontend/public/index.html
@@ -26,8 +26,8 @@
     -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Inter:wght@400;500;600;700;800&display=swap" as="style">
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;800&family=Inter:wght@400;500;600;700;800&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;800&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <title>React App</title>
   </head>
   <body>

--- a/packages/frontend/src/components/Button.module.css
+++ b/packages/frontend/src/components/Button.module.css
@@ -2,3 +2,10 @@
   @apply stroke-current;
   stroke-width: 1.5;
 }
+
+.disabled {
+  @apply bg-gray-200 text-gray-500;
+}
+.input .disabled {
+  @apply bg-red-100 text-red-500;
+}

--- a/packages/frontend/src/components/Button.tsx
+++ b/packages/frontend/src/components/Button.tsx
@@ -48,7 +48,7 @@ const Button: React.FC<Styled<Props>> = ({
         56: 'h-14 text-sub',
       }[height],
       disabled
-        ? 'bg-gray-200 text-gray-500'
+        ? styles.disabled
         : {
           primary: 'text-white bg-primary-500 hover:bg-primary-500 focus:bg-primary-500 active:bg-primary-700 shadow-color-primary',
           destructive: 'text-white bg-red-500 hover:bg-red-500 focus:bg-red-500 active:bg-red-700 shadow-color-destructive',

--- a/packages/frontend/src/components/Button.tsx
+++ b/packages/frontend/src/components/Button.tsx
@@ -6,26 +6,29 @@ import styles from './Button.module.css';
 
 interface Props {
   type: 'primary' | 'destructive' | 'neutral';
-  disabled: boolean;
+  disabled?: boolean;
   text?: string;
   width: 'full' | 'fit-content';
-  height: 36 | 48 | 56;
+  height?: 36 | 48 | 56;
   icon?: React.ReactElement | null; // of `20Regular`
   onClick?: React.MouseEventHandler;
+  ref_?: React.RefObject<HTMLButtonElement>;
 }
 
 const Button: React.FC<Styled<Props>> = ({
   type,
-  disabled,
+  disabled = false,
   text,
   width,
-  height,
+  height = 48,
   icon,
   onClick,
+  ref_,
   className,
   style,
 }) => (
   <button
+    ref={ref_}
     type="button"
     className={mergeClassNames(
       'rounded-full outline-none flex items-center justify-center font-bold transition-button duration-button',

--- a/packages/frontend/src/components/TextInput.module.css
+++ b/packages/frontend/src/components/TextInput.module.css
@@ -1,0 +1,10 @@
+.icon > * {
+  @apply stroke-current;
+  stroke-width: 1;
+}
+.focusWithin:focus-within {
+  color: rgba(63, 63, 70);
+}
+.focusWithinInvalid:focus-within {
+  color: #F5323C;
+}

--- a/packages/frontend/src/components/TextInput.tsx
+++ b/packages/frontend/src/components/TextInput.tsx
@@ -1,0 +1,137 @@
+import { Checkmark20Regular, Dismiss20Regular } from '@fluentui/react-icons';
+import React from 'react';
+
+import { mergeClassNames, mergeStyles, Styled } from '../utils/style';
+
+import styles from './TextInput.module.css';
+
+interface Props {
+  value: string;
+  onInput?: (newText: string) => void;
+  icon?: React.ReactElement | null; // `20Regular`
+  type?: 'text' | 'password';
+  name?: string;
+  autoComplete?: string;
+  readOnly?: boolean;
+  font?: 'sans' | 'mono';
+  placeholderText?: string;
+  align?: 'left' | 'center' | 'right';
+  button?: React.ReactElement; // of height 48
+  onSubmit?: (value: string) => void;
+  validator?: (value: string) => boolean;
+  nextRef?: React.RefObject<HTMLInputElement> | React.MutableRefObject<HTMLButtonElement>;
+  containerStyle?: React.CSSProperties;
+  containerClassName?: string;
+}
+
+const TextInput: React.FC<Styled<Props>> = ({
+  value,
+  onInput,
+  icon,
+  type = 'text',
+  name,
+  autoComplete = name,
+  readOnly = false,
+  font = 'sans',
+  placeholderText,
+  align = 'left',
+  button,
+  onSubmit,
+  validator,
+  nextRef,
+  style,
+  className,
+  containerStyle,
+  containerClassName,
+}) => {
+  const buttonWrapperRef = React.useRef<HTMLDivElement>(null);
+
+  const paddingRightButton = button ? buttonWrapperRef.current?.clientWidth ?? 0 : 0;
+  const paddingRightValidation = validator ? 28 : 0;
+  const paddingRight = 20 + paddingRightValidation + paddingRightButton;
+
+  const isValid = validator ? validator(value) : true;
+
+  return (
+    <div
+      style={containerStyle}
+      className={mergeClassNames(
+        containerClassName,
+        'relative w-full h-12',
+        isValid ? styles.focusWithin : styles.focusWithinInvalid,
+        isValid ? 'text-gray-500' : 'text-red-300',
+      )}
+    >
+      {icon && (
+        <div className={mergeClassNames(
+          'absolute left-5 top-3.5 select-none pointer-events-none',
+          styles.icon,
+        )}
+        >
+          {icon}
+        </div>
+      )}
+      <input
+        type={type}
+        name={name ?? (type === 'password' ? 'password' : undefined)}
+        autoComplete={autoComplete ?? (type === 'password' ? 'password' : undefined)}
+        style={mergeStyles(
+          {
+            '--tw-ring-color': isValid ? 'currentColor' : '#F5323C',
+            textAlign: align,
+            paddingRight,
+          } as React.CSSProperties,
+          style,
+        )}
+        className={mergeClassNames(
+          className,
+          'text-gray-900 text-emph w-full h-full rounded-full placeholder-sans outline-none border-none focus:ring-2',
+          isValid ? 'bg-gray-200' : 'bg-red-100 bg-opacity-50',
+          font === 'sans' ? 'font-sans' : 'font-mono',
+          icon ? 'pl-14' : 'pl-5',
+        )}
+        placeholder={placeholderText}
+        value={value}
+        onInput={(e) => {
+          if (onInput) {
+            onInput(e.currentTarget.value);
+          }
+        }}
+        onKeyPress={(e) => {
+          if (e.key === 'Enter' && (validator ? validator(value) : !!value)) {
+            if (onSubmit) {
+              onSubmit(value);
+            }
+            if (nextRef?.current) {
+              nextRef.current.focus();
+            }
+          }
+        }}
+        readOnly={readOnly}
+      />
+      {button && (
+        <div className="absolute right-0 top-0">
+          <div className="w-fit h-fit" ref={buttonWrapperRef}>
+            {button}
+          </div>
+        </div>
+      )}
+      {validator && (
+        <div
+          className={mergeClassNames(
+            'absolute top-3.5 select-none pointer-events-none',
+            isValid ? 'text-blue-500' : 'text-red-500',
+            styles.icon,
+          )}
+          style={{
+            right: 20 + paddingRightButton,
+          }}
+        >
+          {isValid ? <Checkmark20Regular /> : <Dismiss20Regular />}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TextInput;

--- a/packages/frontend/src/components/TextInput.tsx
+++ b/packages/frontend/src/components/TextInput.tsx
@@ -45,8 +45,13 @@ const TextInput: React.FC<Styled<Props>> = ({
   containerClassName,
 }) => {
   const buttonWrapperRef = React.useRef<HTMLDivElement>(null);
+  const [buttonWidth, setButtonWidth] = React.useState(0);
 
-  const paddingRightButton = button ? buttonWrapperRef.current?.clientWidth ?? 0 : 0;
+  React.useEffect(() => {
+    setButtonWidth(button ? buttonWrapperRef.current?.clientWidth ?? 0 : 0);
+  }, [button, validator, buttonWrapperRef.current, buttonWrapperRef.current?.clientWidth]);
+
+  const paddingRightButton = buttonWidth;
   const paddingRightValidation = validator ? 28 : 0;
   const paddingRight = 20 + paddingRightValidation + paddingRightButton;
 

--- a/packages/frontend/src/components/TextInput.tsx
+++ b/packages/frontend/src/components/TextInput.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { mergeClassNames, mergeStyles, Styled } from '../utils/style';
 
+import buttonStyles from './Button.module.css';
 import styles from './TextInput.module.css';
 
 interface Props {
@@ -65,6 +66,7 @@ const TextInput: React.FC<Styled<Props>> = ({
         'relative w-full h-12',
         isValid ? styles.focusWithin : styles.focusWithinInvalid,
         isValid ? 'text-gray-500' : 'text-red-300',
+        buttonStyles.input,
       )}
     >
       {icon && (

--- a/packages/frontend/src/components/TextInput.tsx
+++ b/packages/frontend/src/components/TextInput.tsx
@@ -19,7 +19,7 @@ interface Props {
   button?: React.ReactElement; // of height 48
   onSubmit?: (value: string) => void;
   validator?: (value: string) => boolean;
-  nextRef?: React.RefObject<HTMLInputElement> | React.MutableRefObject<HTMLButtonElement>;
+  nextRef?: React.RefObject<HTMLInputElement> | React.RefObject<HTMLButtonElement>;
   containerStyle?: React.CSSProperties;
   containerClassName?: string;
 }
@@ -124,7 +124,7 @@ const TextInput: React.FC<Styled<Props>> = ({
             styles.icon,
           )}
           style={{
-            right: 20 + paddingRightButton,
+            right: button ? 12 + paddingRightButton : 20,
           }}
         >
           {isValid ? <Checkmark20Regular /> : <Dismiss20Regular />}

--- a/packages/frontend/src/components/test/ButtonTest.tsx
+++ b/packages/frontend/src/components/test/ButtonTest.tsx
@@ -5,57 +5,9 @@ import React from 'react';
 import { useRecoilState } from 'recoil';
 
 import themeState from '../../recoil/theme';
-import { mergeClassNames } from '../../utils/style';
 import Button from '../Button';
 
-interface RadioInputProps {
-  labelClassName?: string;
-  inputClassName?: string;
-  checked: boolean;
-  text: string;
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
-}
-
-const RadioInput: React.FC<RadioInputProps> = ({
-  labelClassName, inputClassName, checked, text, onChange,
-}) => (
-  <label className={
-    mergeClassNames(
-      'inline-flex items-center mt-3 px-3 py-2 rounded-xl transition-all cursor-pointer',
-      labelClassName,
-    )
-  }
-  >
-    <input
-      type="radio"
-      className={mergeClassNames('cursor-pointer form-radio h-5 w-5', inputClassName)}
-      checked={checked}
-      onChange={onChange}
-    />
-    <span className="ml-2 text-gray-700">{text}</span>
-  </label>
-);
-
-const CheckboxInput: React.FC<RadioInputProps> = ({
-  labelClassName, inputClassName, checked, text, onChange,
-}) => (
-  <label
-    className={
-      mergeClassNames(
-        'inline-flex items-center mt-3 px-3 py-2 rounded-xl transition-all cursor-pointer',
-        labelClassName,
-      )
-    }
-  >
-    <input
-      type="checkbox"
-      className={mergeClassNames('cursor-pointer form-radio h-5 w-5', inputClassName)}
-      checked={checked}
-      onChange={onChange}
-    />
-    <span className="ml-2 text-gray-700">{text}</span>
-  </label>
-);
+import { RadioInput, CheckboxInput } from './TestComponents';
 
 const ButtonTest: React.FC = () => {
   const [theme, setTheme] = useRecoilState(themeState.atom);

--- a/packages/frontend/src/components/test/TestComponents.tsx
+++ b/packages/frontend/src/components/test/TestComponents.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* istanbul ignore file */
+import React from 'react';
+
+import { mergeClassNames } from '../../utils/style';
+
+interface RadioInputProps {
+  labelClassName?: string;
+  inputClassName?: string;
+  checked: boolean;
+  text: string;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+export const RadioInput: React.FC<RadioInputProps> = ({
+  labelClassName, inputClassName, checked, text, onChange,
+}) => (
+  <label className={
+      mergeClassNames(
+        'inline-flex items-center mt-3 px-3 py-2 rounded-xl transition-all cursor-pointer',
+        labelClassName,
+      )
+    }
+  >
+    <input
+      type="radio"
+      className={mergeClassNames('cursor-pointer form-radio h-5 w-5', inputClassName)}
+      checked={checked}
+      onChange={onChange}
+    />
+    <span className="ml-2 text-gray-700">{text}</span>
+  </label>
+);
+
+export const CheckboxInput: React.FC<RadioInputProps> = ({
+  labelClassName, inputClassName, checked, text, onChange,
+}) => (
+  <label
+    className={
+        mergeClassNames(
+          'inline-flex items-center mt-3 px-3 py-2 rounded-xl transition-all cursor-pointer',
+          labelClassName,
+        )
+      }
+  >
+    <input
+      type="checkbox"
+      className={mergeClassNames('cursor-pointer form-radio h-5 w-5', inputClassName)}
+      checked={checked}
+      onChange={onChange}
+    />
+    <span className="ml-2 text-gray-700">{text}</span>
+  </label>
+);

--- a/packages/frontend/src/components/test/TextInputTest.tsx
+++ b/packages/frontend/src/components/test/TextInputTest.tsx
@@ -95,7 +95,7 @@ const TextInputText: React.FC = () => {
           ) : icon === 2 ? (
             <Button
               ref_={buttonRef}
-              icon={<Send20Regular />}
+              icon={<Send20Regular className="block" style={{ transform: 'translateX(1px)' }} />}
               type="primary"
               width="fit-content"
               onClick={() => setText('')}

--- a/packages/frontend/src/components/test/TextInputTest.tsx
+++ b/packages/frontend/src/components/test/TextInputTest.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 /* eslint-disable max-len */
 /* istanbul ignore file */
 import {
@@ -5,6 +6,7 @@ import {
   NumberSymbol20Regular,
   Mail20Regular,
   Password24Regular,
+  Send20Regular,
 } from '@fluentui/react-icons';
 import React from 'react';
 
@@ -90,7 +92,18 @@ const TextInputText: React.FC = () => {
               text="Reset"
               onClick={() => setText(generateClassroomHash())}
             />
+          ) : icon === 2 ? (
+            <Button
+              ref_={buttonRef}
+              icon={<Send20Regular />}
+              type="primary"
+              width="fit-content"
+              onClick={() => setText('')}
+              disabled={!emailValidator(text)}
+            />
           ) : undefined}
+          nextRef={icon === 2 ? buttonRef : undefined}
+          name={icon === 2 ? 'email' : undefined}
           validator={icon !== 2 ? undefined : emailValidator}
         />
       </div>

--- a/packages/frontend/src/components/test/TextInputTest.tsx
+++ b/packages/frontend/src/components/test/TextInputTest.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable max-len */
+/* istanbul ignore file */
+import {
+  ArrowCounterclockwise20Regular,
+  NumberSymbol20Regular,
+  Mail20Regular,
+  Password24Regular,
+} from '@fluentui/react-icons';
+import React from 'react';
+
+import Button from '../Button';
+import TextInput from '../TextInput';
+
+import { RadioInput } from './TestComponents';
+
+function emailValidator(emailAddress: string) {
+  const sQtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]';
+  const sDtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]';
+  const sAtom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+';
+  const sQuotedPair = '\\x5c[\\x00-\\x7f]';
+  const sDomainLiteral = `\\x5b(${sDtext}|${sQuotedPair})*\\x5d`;
+  const sQuotedString = `\\x22(${sQtext}|${sQuotedPair})*\\x22`;
+  const sDomainRef = sAtom;
+  const sSubDomain = `(${sDomainRef}|${sDomainLiteral})`;
+  const sWord = `(${sAtom}|${sQuotedString})`;
+  const sDomain = `${sSubDomain}(\\x2e${sSubDomain})*`;
+  const sLocalPart = `${sWord}(\\x2e${sWord})*`;
+  const sAddrSpec = `${sLocalPart}\\x40${sDomain}`; // complete RFC822 email address spec
+  const sValidEmail = `^${sAddrSpec}$`; // as whole string
+
+  const reValidEmail = new RegExp(sValidEmail);
+
+  return reValidEmail.test(emailAddress);
+}
+
+function generateClassroomHash(): string {
+  const generateSyllable = (): string => {
+    const random = (arr: string[]) => arr[Math.floor(Math.random() * arr.length)];
+    const first = ['B', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'S', 'T', 'W'];
+    const second = ['A', 'E', 'I', 'O', 'U'];
+    const third = ['K', 'L', 'M', 'N', 'P', 'S', 'T', 'Z'];
+
+    return `${random(first)}${random(second)}${random(third)}`;
+  };
+
+  return `${generateSyllable()}-${generateSyllable()}-${generateSyllable()}`;
+}
+
+const TextInputText: React.FC = () => {
+  const [icon, setIcon] = React.useState(0);
+  const [text, setText] = React.useState('');
+
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (icon === 1) {
+      setText(generateClassroomHash());
+    } else if (icon === 2) {
+      setText('example@email.com');
+    }
+  }, [icon]);
+
+  return (
+    <div className="w-full h-full flex flex-col justify-center items-center">
+      <div className="flex gap-8 w-fit">
+        <RadioInput inputClassName="text-gray-700" labelClassName="hover:bg-gray-200" checked={icon === 0} text="None" onChange={() => setIcon(0)} />
+        <RadioInput inputClassName="text-gray-700" labelClassName="hover:bg-gray-200" checked={icon === 1} text="Hash" onChange={() => setIcon(1)} />
+        <RadioInput inputClassName="text-gray-700" labelClassName="hover:bg-gray-200" checked={icon === 2} text="Email" onChange={() => setIcon(2)} />
+        <RadioInput inputClassName="text-gray-700" labelClassName="hover:bg-gray-200" checked={icon === 3} text="Password" onChange={() => setIcon(3)} />
+      </div>
+      <div className="px-12 w-full max-w-md h-14 flex justify-center items-center mt-8">
+        <TextInput
+          value={text}
+          onInput={setText}
+          icon={{
+            0: null,
+            1: <NumberSymbol20Regular />,
+            2: <Mail20Regular />,
+            3: <div style={{ transform: 'scale(91.6%) translate(-2px,-2px)' }}><Password24Regular /></div>,
+          }[icon]}
+          font={icon !== 0 ? 'mono' : 'sans'}
+          type={icon === 3 ? 'password' : 'text'}
+          readOnly={icon === 1}
+          button={icon === 1 ? (
+            <Button
+              ref_={buttonRef}
+              icon={<ArrowCounterclockwise20Regular />}
+              type="destructive"
+              width="fit-content"
+              text="Reset"
+              onClick={() => setText(generateClassroomHash())}
+            />
+          ) : undefined}
+          validator={icon !== 2 ? undefined : emailValidator}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TextInputText;

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -39,6 +39,11 @@ button {
   }
   .placeholder-mono::placeholder {
     @apply font-mono;
+    letter-spacing: -0.05em;
+  }
+
+  .font-mono {
+    letter-spacing: -0.05em;
   }
 }
 

--- a/packages/frontend/src/pages/Test.tsx
+++ b/packages/frontend/src/pages/Test.tsx
@@ -8,6 +8,7 @@ import AudioVisualizerTest from '../components/test/AudioVisualizerTest';
 import ButtonTest from '../components/test/ButtonTest';
 import DropdownTest from '../components/test/DropdownTest';
 import JoinCreatePageTest from '../components/test/JoinCreatePageTest';
+import TextInputTest from '../components/test/TextInputTest';
 import ToastTest from '../components/test/ToastTest';
 
 /** 여기에 테스트할 컴포넌트를 넣어주세요! `pathname: ['설명', 컴포넌트]` 형식 */
@@ -17,6 +18,7 @@ const componentsToTest: Record<string, [string, React.ReactElement]> = {
   toast: ['Toasts', <ToastTest />],
   joincreate: ['Join/Create Class', <JoinCreatePageTest />],
   buttons: ['Buttons', <ButtonTest />],
+  'text-input': ['Text Input', <TextInputTest />],
 };
 
 interface Props {

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -70,7 +70,7 @@ module.exports = {
     },
     fontFamily: {
       sans: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'Helvetica Neue', 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', '애플 SD 산돌고딕 Neo', 'Apple SD Gothic Neo', 'Noto Sans CJK KR', 'Noto Sans KR', 'Noto Sans', '본고딕', 'Source Han Sans', '나눔바른고딕', 'NanumBarunGothic', '나눔바른고딕OTF', 'NanumBarunGothicOTF', '맑은 고딕', 'Malgun Gothic', 'Helvetica Neue', 'Helvetica', 'Dotum', '돋움', 'sans-serif'],
-      mono: ['IBM Plex Mono', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', 'monospace'],
+      mono: ['JetBrains Mono', 'IBM Plex Mono', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', '애플 SD 산돌고딕 Neo', 'Apple SD Gothic Neo', 'Noto Sans CJK KR', 'Noto Sans KR', 'Noto Sans', '본고딕', 'Source Han Sans', '나눔바른고딕', 'NanumBarunGothic', '나눔바른고딕OTF', 'NanumBarunGothicOTF', '맑은 고딕', 'Malgun Gothic', 'Helvetica Neue', 'Helvetica', 'Dotum', '돋움', 'sans-serif', 'monospace'],
     },
     fontSize: {
       code: ['.8125rem', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,6 +3647,8 @@ __metadata:
     eslint-config-airbnb: ^19.0.0
     eslint-config-airbnb-typescript: ^15.0.0
     eslint-plugin-import: ^2.25.3
+    socket.io: ^4.3.2
+    typescript: ^4.4.4
   languageName: unknown
   linkType: soft
 
@@ -18878,6 +18880,20 @@ __metadata:
     socket.io-adapter: ~2.3.2
     socket.io-parser: ~4.0.4
   checksum: 8552f9cdf47fa121393c26c6f5aa526110813865b18f73e4c481a3057f5e095e5508e7c1c9dc57f341b0c6fe4fc970fb43baf33868732e2c2a38540cbf64805c
+  languageName: node
+  linkType: hard
+
+"socket.io@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "socket.io@npm:4.3.2"
+  dependencies:
+    accepts: ~1.3.4
+    base64id: ~2.0.0
+    debug: ~4.3.2
+    engine.io: ~6.0.0
+    socket.io-adapter: ~2.3.2
+    socket.io-parser: ~4.0.4
+  checksum: 7becd040b79de17b3b9ef83375caef89e74f1f1a91578a2b3c6ba1dfa44d2f7b95aa0af7b29f67d21b613cfec0b880d76de4149f752ee1718cbe7f06b307485f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 개요

This PR closes #97.

https://user-images.githubusercontent.com/22598138/142369819-f4131353-5d64-4a79-8301-27b6a9711562.mp4

## Props

```ts
interface Props {
  value: string;
  onInput?: (newText: string) => void;
  icon?: React.ReactElement | null; // `20Regular`
  type?: 'text' | 'password';
  name?: string;
  autoComplete?: string;
  readOnly?: boolean;
  font?: 'sans' | 'mono';
  placeholderText?: string;
  align?: 'left' | 'center' | 'right';
  button?: React.ReactElement; // of height 48
  onSubmit?: (value: string) => void;
  validator?: (value: string) => boolean;
  nextRef?: React.RefObject<HTMLInputElement> | React.RefObject<HTMLButtonElement>;
  containerStyle?: React.CSSProperties;
  containerClassName?: string;
}
```
* `value`: 안의 string 값입니다.
* `onInput`: value 값이 변할 때마다 호출됩니다.
* `icon`: 왼쪽에 붙는 아이콘입니다. 20x20의 아이콘을 전달해 주세요.
* `type`: `text`인지 `password`인지의 prop입니다. 기본값은 `text`입니다.
* `name`: input tag의 name property입니다.
* `button`: `<Button />`을 전달해 주시면 됩니다. 버튼의 `width` 값은 `fit-content`로 설정해 주세요.
* `onSubmit`: 인풋에서 엔터 키를 눌렀을 때 실행됩니다.
* `validator`: value가 valid한지 알려주는 함수입니다.
* `nextRef`: 엔터 키를 눌렀을 때 포커스를 잡을 요소의 ref입니다. **만약 `button`이 있다면 `nextRef`를 그 버튼의 ref로 설정해 주셔야 합니다.**
* `containerStyle/ClassName`: 가장 바깥의 div의 style/className입니다.

## `nextRef`, `onSubmit`, `validator`, `autoComplete` 예시


https://user-images.githubusercontent.com/22598138/142372326-27b166d8-f8e4-4c9d-8366-197d56404ff4.mp4


