### PR TITLE
fix(global.tsx): added className and style as props for Global

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
 
   return (
     <Router>
-      <Global />
+      <Global className={`theme-${theme}`} />
       <Layout className={`theme-${theme}`}>
         <Route exact path="/tests/" render={() => <Test name="" />} />
         <Route

--- a/packages/frontend/src/components/Global.tsx
+++ b/packages/frontend/src/components/Global.tsx
@@ -31,7 +31,7 @@ const Global: React.FC<Styled<{}>> = ({ className, style }) => {
   const history = useHistory();
 
   return (
-    <>
+    <div className={className} style={style}>
       {/* 화면 vh 조정 */}
       <ScreenHeightMeasure />
 
@@ -59,7 +59,7 @@ const Global: React.FC<Styled<{}>> = ({ className, style }) => {
       </YTWrapper>
 
       <ToastDisplay toasts={toasts} />
-    </>
+    </div>
   );
 };
 

--- a/packages/frontend/src/components/Global.tsx
+++ b/packages/frontend/src/components/Global.tsx
@@ -19,7 +19,7 @@ import ToastDisplay from './ToastDisplay';
 import YTPlayer from './YTPlayer';
 import YTWrapper from './YTWrapper';
 
-const Global: React.FC = () => {
+const Global: React.FC<Styled<{}>> = ({ className, style }) => {
   const classroom = useRecoilValue(classroomState.atom);
   const dropdown = useRecoilValue(dropdownState.atom);
   const dialog = useRecoilValue(dialogState.atom);


### PR DESCRIPTION
This PR closes #116

Global 컴포넌트의 className과 style를 props로 전달하여 Dropdown에 theme이 적용안되는 에러를 해결했습니다.

수정 코드
packages/frontend/src/components/Global.tsx
const Global: React.FC<Styled<{}>> = ({className, style}) => {

frontend/src/App.tsx
<Global className={\theme-${theme}`} />`