### PR TITLE
feat(frontend): Implemented footer

### DIFF
--- a/packages/frontend/src/components/layout/Footer.tsx
+++ b/packages/frontend/src/components/layout/Footer.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable max-len */
+import { Speaker224Filled, EyeShow24Filled } from '@fluentui/react-icons';
+import { MemberJSON } from '@team-10/lib';
+import React, { CSSProperties } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import useMainClassroom from '../../hooks/useMainClassroom';
+import useScreenType from '../../hooks/useScreenType';
+import meState from '../../recoil/me';
+import ScreenType from '../../types/screen';
+import AmbientButton from '../buttons/AmbientButton';
+
+import FooterMember from './FooterMember';
+
+interface Props {
+  members: MemberJSON[];
+}
+
+const Footer: React.FC<Props> = ({ members }) => {
+  const screenType = useScreenType();
+  const location = useLocation();
+  const history = useHistory();
+  const me = useRecoilValue(meState.atom);
+  const mainClassroom = useMainClassroom();
+  const inClassroom = /^\/classrooms\/\w{3}-\w{3}-\w{3}$/.test(location.pathname);
+
+  let displayCount = 6;
+
+  return (
+    (screenType === ScreenType.Desktop || screenType === ScreenType.MobilePortrait ? (
+      <div
+        className="flex fixed border-t-4 border-primary-500 bg-white z-layout bottom-0 w-100vw items-center content-center justify-between"
+        style={{ height: 'calc(env(safe-area-inset-bottom, 0px) + 76px)' }}
+      >
+        <div className="flex items-center content-center justify-center">
+          {/* Members in the current class */}
+          {members.map((member) => {
+            displayCount -= 1;
+            return (
+              (member.isHost || member.isSpeaking || member.isMe) ? (
+                <FooterMember
+                  name={member.id}
+                  img={member.img}
+                  isHost={member.isHost}
+                  isMe={member.isMe}
+                  isSpeaking={member.isSpeaking}
+                />
+              ) : screenType === ScreenType.Desktop && displayCount >= 0 ? (
+                <FooterMember
+                  name={member.id}
+                  img={member.img}
+                  isHost={member.isHost}
+                  isMe={member.isMe}
+                  isSpeaking={member.isSpeaking}
+                />
+              ) : screenType === ScreenType.MobilePortrait && displayCount >= 2 ? (
+                <FooterMember
+                  name={member.id}
+                  img={member.img}
+                  isHost={member.isHost}
+                  isMe={member.isMe}
+                  isSpeaking={member.isSpeaking}
+                />
+              ) : (
+                ''
+              ));
+          })}
+          {/* Number of users in the current class */}
+          {screenType === ScreenType.Desktop && members.length > 6 && (
+            <div className="font-bold order-last">
+              +
+              {members.length - 6}
+            </div>
+          )}
+          {screenType === ScreenType.MobilePortrait && members.length > 4 && (
+            <div className="font-bold order-last">
+              +
+              {members.length - 4}
+            </div>
+          )}
+        </div>
+        {/* Speaking button when in class */}
+        <div className="justify-end order-last">
+          {inClassroom ? (
+            <div className="w-10">
+              <AmbientButton
+                alt="Speak"
+                className="font-bold bg-pink-500"
+                icon={<Speaker224Filled />}
+                onClick={() => {
+                }} // TODO
+              >
+                Speak
+              </AmbientButton>
+            </div>
+          ) : (
+            <div className="flex px-7 font-bold">
+              {/* mainClassroom?.name */}
+              전산학특강: 프런트엔드 개발
+            </div>
+          )}
+        </div>
+      </div>
+    ) : screenType === ScreenType.MobileLandscape ? (
+      <div
+        className="flex fixed z-layout bottom-0 w-100vw items-center content-center justify-end"
+        style={{ height: 'calc(env(safe-area-inset-bottom, 0px) + 76px)' }}
+      >
+        <AmbientButton
+          alt="Chat Visibility"
+          className="bg-gray-500 mx-2"
+          icon={<EyeShow24Filled />}
+          onClick={() => {
+          }} // TODO
+        />
+        <AmbientButton
+          alt="Speak"
+          className="bg-gray-500 ml-2 mr-4"
+          icon={<Speaker224Filled />}
+          onClick={() => {
+          }} // TODO
+        />
+      </div>
+    ) : (
+      <div>Empty</div>
+    ))
+  );
+};
+
+export default Footer;

--- a/packages/frontend/src/components/layout/FooterMember.tsx
+++ b/packages/frontend/src/components/layout/FooterMember.tsx
@@ -1,0 +1,50 @@
+import {
+  Person20Filled,
+  Person24Filled,
+  Star12Filled,
+} from '@fluentui/react-icons';
+
+import React from 'react';
+
+import { mergeClassNames, Styled } from '../../utils/style';
+import AmbientButton from '../buttons/AmbientButton';
+
+interface Props {
+  name: string;
+  img: string;
+  isHost: boolean;
+  isMe: boolean;
+  isSpeaking: boolean;
+}
+
+const FooterMember: React.FC<Styled<Props>> = ({
+  name, img, isHost, isMe, isSpeaking,
+}) => (
+  <div className={isHost ? 'order-3' : isSpeaking ? 'order-2' : isMe ? 'order-1' : 'order-4'}>
+    { isSpeaking ? (
+      <>
+        <span className="animate-ping-small absolute w-10 h-10 ml-2 mr-2 px-2 py-2 bg-primary-500 opacity-75 rounded-full" />
+        <div className="w-10 h-10 ml-2 mr-2 px-2 py-2 bg-primary-500 rounded-full items-center content-center justify-center">
+          <Person24Filled />
+        </div>
+      </>
+    ) : isMe ? (
+      <div className="w-10 h-10 ml-2 mr-2 px-2 py-2 bg-blue-500 rounded-full items-center content-center justify-center">
+        <Person24Filled />
+      </div>
+    ) : isHost ? (
+      <div className="w-10 h-10 ml-2 mr-2 px-2 py-2 bg-gray-500 rounded-full items-center content-center justify-center">
+        <Person24Filled />
+        <div className="w-4 h-4 bottom-0 right-5px items-center content-center justify-center rounded-full bg-pink-500">
+          <Star12Filled />
+        </div>
+      </div>
+    ) : (
+      <div className="w-8 h-8 ml-2 mr-2 px-2 py-2 bg-gray-500 rounded-full items-center content-center justify-center">
+        <Person20Filled />
+      </div>
+    )}
+  </div>
+);
+
+export default FooterMember;

--- a/packages/frontend/src/components/layout/Layout.tsx
+++ b/packages/frontend/src/components/layout/Layout.tsx
@@ -2,16 +2,14 @@ import React from 'react';
 
 import { mergeClassNames, Styled } from '../../utils/style';
 
+import Footer from './Footer';
+import FooterTest from '../test/FooterTest';
 import Header from './Header';
 
 const Layout: React.FC<Styled<{}>> = ({ className, style, children }) => (
   <div style={style} className={mergeClassNames('w-full h-full bg-white absolute top-0 overflow-auto', className)}>
     <Header />
-    {/* Dummy Footer */}
-    <div
-      className="fixed border-t-4 border-primary-500 bg-white z-layout bottom-0 w-100vw"
-      style={{ height: 'calc(env(safe-area-inset-bottom, 0px) + 76px)' }}
-    />
+    <FooterTest />
 
     {/* Contents */}
     <div

--- a/packages/frontend/src/components/test/FooterTest.tsx
+++ b/packages/frontend/src/components/test/FooterTest.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import Footer from '../layout/Footer';
+
+const members = [{
+  id: 'Alice',
+  img: 'dummy',
+  isHost: true,
+  isMe: false,
+  isSpeaking: false,
+},
+{
+  id: 'Bob',
+  img: 'dummy',
+  isHost: false,
+  isMe: false,
+  isSpeaking: true,
+},
+{
+  id: 'Charlie',
+  img: 'dummy',
+  isHost: false,
+  isMe: true,
+  isSpeaking: false,
+},
+{
+  id: 'David',
+  img: 'dummy',
+  isHost: false,
+  isMe: false,
+  isSpeaking: false,
+},
+{
+  id: 'David',
+  img: 'dummy',
+  isHost: false,
+  isMe: false,
+  isSpeaking: false,
+},
+{
+  id: 'David',
+  img: 'dummy',
+  isHost: false,
+  isMe: false,
+  isSpeaking: false,
+},
+{
+  id: 'David',
+  img: 'dummy',
+  isHost: false,
+  isMe: false,
+  isSpeaking: false,
+},
+{
+  id: 'David',
+  img: 'dummy',
+  isHost: false,
+  isMe: false,
+  isSpeaking: false,
+}];
+
+const FooterTest: React.FC = () => (<Footer members={members} />);
+
+export default FooterTest;

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -32,6 +32,9 @@ module.exports = {
   },
   darkMode: false,
   theme: {
+    animation: {
+      'ping-small': 'ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite',
+    },
     boxShadow: {
       button: '0 3px 8px var(--shadow-color)',
       'button-hover': '0 6px 16px var(--shadow-color)',

--- a/packages/lib/src/types/classroom.ts
+++ b/packages/lib/src/types/classroom.ts
@@ -22,3 +22,12 @@ export interface ClassroomJSON {
   passcode: string;
   updatedAt: number;
 }
+
+export interface MemberJSON {
+  id: string;
+  img: string;
+  isHost: boolean;
+  isMe: boolean;
+  isSpeaking: boolean; 
+}
+


### PR DESCRIPTION
feat: #28 를 구현했습니다.

## 기능
### Desktop
![image](https://user-images.githubusercontent.com/30403155/143570547-35dc13ea-21af-43b9-b0c8-5df066f4db3a.png)

### MobilePortrait
![image](https://user-images.githubusercontent.com/30403155/143572078-011b1000-48fb-470e-a389-09a6ec6b1032.png)

### MobileLandscape (in class)
![image](https://user-images.githubusercontent.com/30403155/143570860-0a0ced2f-a888-42be-87d3-b28342d3612b.png)

* 만약 class에 들어가있으면 밑에 현재 멤버들이 나열됩니다.
* 언제나 가장 먼저 본인, Speaker, Host, 그 외 순서로 나열됩니다.
* 언제나 본인은 파랑색, Speaker는 분홍색입니다.
* Speaker는 animation-ping을 사용했습니다 (tailwind.config에 custom으로 되어있습니다).
* Host에게는 별이 달립니다.
* 이 때 Desktop과 MobileLandscape에서는 총 6명까지, MobilePortrait에서는 총 4명까지 나옵니다. 나머지는 뒤에 +[나머지 숫자]로 보여집니다.

## 테스트
* 테스트를 해보고 싶다면 FooterTest.tsx에서 members안에 있는 JSON을 바꿔주시길 바랍니다.

## 더 해야하는 기능
* CSS (centered랑 host) 문제 해결
* 본인, Speaker, Host 멤버 외의 배경 색깔 변경 또는 id 첫 글자 사용
* MobilePortrait일때 채팅 인터페이스 보여주기
* MobileLandscape이고 class 밖에 있을 때 세팅
* MobileLandscape에서 ViewButtonChat을 구현해서 클릭하면 chat이 보이거나 사라지는 기능
* Speak 버튼이랑 실제 speaking 기능 합치기